### PR TITLE
Add accelerate dependency for CPU training

### DIFF
--- a/model_training/cpu/requirements.txt
+++ b/model_training/cpu/requirements.txt
@@ -13,6 +13,7 @@ tqdm>=4.66
 # Hugging Face ecosystem
 datasets>=2.19
 transformers>=4.45,<4.48
+accelerate>=0.26.1
 evaluate>=0.5
 sentencepiece>=0.1.99
 


### PR DESCRIPTION
## Summary
- include `accelerate>=0.26.1` in CPU training requirements

## Testing
- `python -m py_compile model_training/cpu/cpu-train.py`

------
https://chatgpt.com/codex/tasks/task_e_687390ed0e68833390f775908e53edce