### PR TITLE
Add checkpoint resume support

### DIFF
--- a/model_training/gpu/gpu-train-2080ti-oom-safe.py
+++ b/model_training/gpu/gpu-train-2080ti-oom-safe.py
@@ -142,7 +142,14 @@ trainer = Trainer(model=model,
 # ───────── train ──────────────────────────────────────────────────
 log("Training …")
 t0 = time.time()
-trainer.train()
+# Auto-resume from the latest checkpoint if one exists
+last_ckpt = None
+if os.path.isdir(args.output_dir):
+    from transformers.trainer_utils import get_last_checkpoint
+    last_ckpt = get_last_checkpoint(args.output_dir)
+    if last_ckpt:
+        log(f"Resuming from checkpoint {last_ckpt}")
+trainer.train(resume_from_checkpoint=last_ckpt)
 log(f"Training done in {(time.time()-t0)/60:.1f} min")
 
 # ───────── save & cleanup ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- resume training from the last checkpoint if present

## Testing
- `python3 -m py_compile model_training/gpu/gpu-train-2080ti-oom-safe.py`

------
https://chatgpt.com/codex/tasks/task_e_6873a3aaca7083339303eff53c64aaee